### PR TITLE
Fix comments parser

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -415,7 +415,7 @@ module.exports = grammar({
     fraction: ($) => prec.left(seq(".", repeat1($.digit))),
     exponent: ($) =>
       seq(choice("e", "E"), optional(choice("+", "-")), repeat1($.digit)),
-    comment: ($) => token(seq("#", /[^\n]+/, "\n")),
+    comment: ($) => token(seq("#", /[^\n]*/, "\n")),
     regex: ($) => seq("/", optional($.regex_content), "/"),
     regex_content: ($) => repeat1(choice($.regex_text, $.regex_escaped_char)),
     regex_text: ($) => seq(/[^\n\\\/]+/),


### PR DESCRIPTION
Comments should not require more symbols on the line, see https://hurl.dev/docs/grammar.html#lexical-grammar.

Fixes https://github.com/pfeiferj/vscode-hurl/issues/15